### PR TITLE
Batch process messages if needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "chrono-english",
+ "futures-util",
  "log",
  "pretty_env_logger",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ pretty_env_logger = "0.5.0"
 sqlx = { version = "0.8.2", features = ["chrono", "runtime-tokio", "sqlite"] }
 teloxide = { version = "0.13.0", features = ["macros"] }
 tokio = { version = "1.41.0", features = ["full"] }
+futures-util = "0.3.31"

--- a/migrations/20241030005925_Id_type_fix.sql
+++ b/migrations/20241030005925_Id_type_fix.sql
@@ -1,0 +1,18 @@
+-- Adds the NOT NULL and AUTOINCREMENT specifiers to the message_id column
+-- SQLite can't really change the type specs of columns, so we copy everything over to a new table
+CREATE TABLE messages_temp
+(
+    message_id  INTEGER  NOT NULL PRIMARY KEY AUTOINCREMENT,
+    reply_to_id INTEGER  NOT NULL,
+    chat_id     INTEGER  NOT NULL,
+    when_send   DATETIME NOT NULL
+);
+
+INSERT INTO messages_temp(message_id, reply_to_id, chat_id, when_send)
+SELECT message_id, reply_to_id, chat_id, when_send
+FROM messages;
+
+DROP TABLE messages;
+
+ALTER TABLE messages_temp
+    RENAME TO messages;


### PR DESCRIPTION
Added an index to the messages table, this allows the ORDER BY to be internalized to the storage, which makes queries faster. Not that it matters terribly.

Changed the message reading loop to read all overdue messages from the same query result set before yielding the task.

Also took the opportunity to clean up the naming some, and refactor the select! so that it's not repeated, instead modifying the sleep duration before requesting.